### PR TITLE
feat(state): Add trie

### DIFF
--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -5,3 +5,22 @@ authors = ["Cryptape Technologies <contact@cryptape.com>"]
 edition = "2018"
 
 [dependencies]
+sha3 = "0.8.0"
+hex = "0.3.2"
+rlp = "0.3.0"
+
+hash-db = { git = "https://github.com/paritytech/trie", default-features = false }
+trie-db = { git = "https://github.com/paritytech/trie", optional = true }
+trie-root = { git = "https://github.com/paritytech/trie", default-features = false }
+memory-db = { git = "https://github.com/paritytech/trie", optional = true }
+hash256-std-hasher = { git = "https://github.com/paritytech/trie", optional = true }
+
+[features]
+default = ["std"]
+std = [
+	"hash-db/std",
+	"memory-db",
+	"trie-db",
+	"trie-root/std",
+	"hash256-std-hasher"
+]

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod trie;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/state/src/trie/codec.rs
+++ b/state/src/trie/codec.rs
@@ -1,0 +1,152 @@
+extern crate trie_db;
+extern crate hash_db;
+extern crate hex;
+extern crate rlp;
+
+use std::marker::PhantomData;
+use std::error::Error;
+use std::fmt;
+
+use trie_db::{
+    ChildReference,
+    DBValue,
+    NodeCodec,
+    NibbleSlice,
+    node::Node,
+};
+use hash_db::Hasher;
+use rlp::{Rlp, DecoderError, Prototype, RlpStream, NULL_RLP};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum CodecError {
+    DecodeErr(DecoderError),
+    InvalidData,
+}
+
+impl Error for CodecError {
+	fn description(&self) -> &str {
+		"codec error"
+	}
+}
+
+impl fmt::Display for CodecError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match *self {
+            CodecError::DecodeErr(ref err) => format!("rlp decode {}", err),
+            CodecError::InvalidData => format!("invalid data"),
+        };
+        write!(f, "{}", printable)
+	}
+}
+
+impl From<rlp::DecoderError> for CodecError {
+    fn from(error: rlp::DecoderError) -> Self {
+        CodecError::DecodeErr(error)
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct RLPNodeCodec<H: Hasher>(PhantomData<H>);
+
+impl<H: Hasher> NodeCodec<H> for RLPNodeCodec<H> {
+    type Error = CodecError;
+  
+    fn hashed_null_node() -> H::Out {
+        H::hash(&[0u8][..])
+    }
+  
+    fn decode(data: &[u8]) -> Result<Node, Self::Error> {
+        if data == &[0] {
+            return Ok(Node::Empty);
+        }
+        let r = Rlp::new(data);
+        match r.prototype()? {
+            Prototype::List(2) => {
+                let rlp_key = r.at(0)?.data()?;
+                let value = r.at(1)?.data()?;
+                let (key, is_leaf) = NibbleSlice::from_encoded(rlp_key);
+
+                if is_leaf {
+                    Ok(Node::Leaf(key, &value))
+                } else {
+                    Ok(Node::Extension(key, &value))
+                }
+            },
+            Prototype::List(17) => {
+                let mut nodes: [Option<&[u8]>; 16] = 
+                    [
+                        None, None, None, None,
+                        None, None, None, None,
+                        None, None, None, None,
+                        None, None, None, None,
+                    ];
+                for i in 0..16 {
+                    if !r.at(i)?.is_empty() {
+                        nodes[i] = Some(r.at(i)?.as_raw());
+                    }
+                };
+
+                let value_node = if r.at(16)?.is_empty() { 
+                    None 
+                } else { 
+                    Some(r.at(16)?.data()?) 
+                };
+
+                Ok(Node::Branch(nodes, value_node))
+            },
+            Prototype::Data(0) => Ok(Node::Empty),
+            _ => Err(CodecError::InvalidData),
+        }
+    }
+
+    fn try_decode_hash(data: &[u8]) -> Option<H::Out>{
+        if data.len() == H::LENGTH {
+            Some(H::hash(&data[..]))
+        } else {
+            None
+        }
+    }
+
+    fn is_empty_node(data: &[u8]) -> bool {
+        data == NULL_RLP
+    }
+
+    fn empty_node() -> Vec<u8> {
+        NULL_RLP.to_vec()
+    }
+
+    fn leaf_node(partial: &[u8], value: &[u8]) -> Vec<u8> {
+        let mut stream = RlpStream::new_list(2);
+        stream.append(&&*partial);
+        stream.append(&&*value);
+        stream.out()
+    }
+
+    fn ext_node(partial: &[u8], child_ref: ChildReference<H::Out>) -> Vec<u8> {
+        let mut stream = RlpStream::new_list(2);
+        stream.append(&&*partial);
+        match child_ref {
+			ChildReference::Hash(h) => stream.append(&AsRef::<[u8]>::as_ref(h.as_ref())),
+			ChildReference::Inline(inline_data, len) => stream.append(&AsRef::<[u8]>::as_ref(&inline_data.as_ref())[..len].as_ref()),
+		};
+        stream.out()
+    }
+
+    fn branch_node<I>(children: I, value: Option<DBValue>) -> Vec<u8>
+ 	where I: IntoIterator<Item=Option<ChildReference<H::Out>>> + Iterator<Item=Option<ChildReference<H::Out>>> {
+         let mut stream = RlpStream::new();
+         for child in children {
+             match child {
+                Some(ChildReference::Hash(h)) => stream.append_raw(h.as_ref(), 1),
+                 Some(ChildReference::Inline(inline_data, len)) => stream.
+                    append_raw(&AsRef::<[u8]>::as_ref(&inline_data.as_ref())[..len].as_ref(), 1),
+                None => stream.append_empty_data(),
+             };
+         }
+         match value {
+             Some(value) => stream.append(&&*value),
+             None => stream.append_empty_data(),
+         };
+         stream.out()
+     }
+}

--- a/state/src/trie/codec.rs
+++ b/state/src/trie/codec.rs
@@ -33,7 +33,7 @@ impl fmt::Display for CodecError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let printable = match *self {
             CodecError::DecodeErr(ref err) => format!("rlp decode {}", err),
-            CodecError::InvalidData => format!("invalid data"),
+            CodecError::InvalidData => "invalid data".to_string(),
         };
         write!(f, "{}", printable)
 	}
@@ -56,7 +56,7 @@ impl<H: Hasher> NodeCodec<H> for RLPNodeCodec<H> {
     }
   
     fn decode(data: &[u8]) -> Result<Node, Self::Error> {
-        if data == &[0] {
+        if data == [0] {
             return Ok(Node::Empty);
         }
         let r = Rlp::new(data);
@@ -74,7 +74,7 @@ impl<H: Hasher> NodeCodec<H> for RLPNodeCodec<H> {
             },
             Prototype::List(17) => {
                 let mut nodes = [None; 16];
-                for i in 0..16 {
+                for i in 0..nodes.len() {
                     let data = r.at(i)?;
                     if !data.is_empty() {
                         nodes[i] = Some(data.as_raw());

--- a/state/src/trie/hasher.rs
+++ b/state/src/trie/hasher.rs
@@ -1,0 +1,38 @@
+extern crate hash_db;
+extern crate sha3;
+extern crate hash256_std_hasher;
+
+use hash_db::Hasher;
+use sha3::{Digest, Sha3_256};
+use hash256_std_hasher::Hash256StdHasher;
+
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct Sha3Hasher;
+
+impl Hasher for Sha3Hasher {
+	type Out = [u8; 32];
+	type StdHasher = Hash256StdHasher;
+
+	const LENGTH: usize = 32;
+
+	fn hash(x: &[u8]) -> Self::Out {
+		let mut out = [0u8; Self::LENGTH];
+		out.copy_from_slice(&Sha3_256::digest(x));
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate hex;
+
+    use super::*;
+
+    #[test]
+    fn test_sha3_hasher() {
+        let out1 = Sha3Hasher::hash("test".as_bytes());
+        let out2 = Sha3Hasher::hash("test".as_bytes());
+
+        assert_eq!(out1, out2)
+    }
+}

--- a/state/src/trie/mod.rs
+++ b/state/src/trie/mod.rs
@@ -1,0 +1,124 @@
+extern crate trie_root;
+extern crate trie_db;
+extern crate hash_db;
+extern crate memory_db;
+extern crate hex;
+
+use trie_db::{DBValue};
+
+pub mod hasher;
+pub mod codec;
+
+use self::codec::RLPNodeCodec;
+
+pub type MemoryDB<H> = memory_db::MemoryDB<H, DBValue>;
+pub type RLPTrieDBMut<'a, H> = trie_db::TrieDBMut<'a, H, RLPNodeCodec<H>>;
+pub type RLPTrieDB<'a, H> = trie_db::TrieDB<'a, H, RLPNodeCodec<H>>;
+pub type RLPSecTrieDBMut<'a, H> = trie_db::SecTrieDBMut<'a, H, RLPNodeCodec<H>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trie_db::TrieMut;
+    use super::hasher::{Sha3Hasher};
+
+    #[test]
+    fn test_empty_trie_shoule_be_true() {
+        let mut m = MemoryDB::<Sha3Hasher>::default();
+        let mut root = Default::default();
+        let trie = RLPSecTrieDBMut::new(&mut m, &mut root);
+        assert!(trie.is_empty(), true)
+    }
+
+    #[test]
+    fn test_insert_leaft_node() {
+        let mut m = MemoryDB::<Sha3Hasher>::default();
+        let mut root = Default::default();
+        let mut trie = RLPSecTrieDBMut::new(&mut m, &mut root);
+
+        trie.insert("test-key".as_bytes(), "test-value".as_bytes()).unwrap();
+        let value = trie.get("test-key".as_bytes()).unwrap().unwrap();
+        assert_eq!(value, "test-value".as_bytes())
+    }
+
+    #[test]
+    fn test_insert_branch_node() {
+        let mut m = MemoryDB::<Sha3Hasher>::default();
+        let mut root = Default::default();
+        let mut trie = RLPSecTrieDBMut::new(&mut m, &mut root);
+
+        trie.insert("test-key1".as_bytes(), "test-vlue".as_bytes()).unwrap();
+        trie.insert("test-key2".as_bytes(), "test-value".as_bytes()).unwrap();
+        trie.insert("test-key3".as_bytes(), "test-value".as_bytes()).unwrap();
+        trie.insert("test-key4".as_bytes(), "test-value".as_bytes()).unwrap();
+
+        trie.root();
+    }
+
+    #[test]
+    fn test_insert_ext_node() {
+        let mut m = MemoryDB::<Sha3Hasher>::default();
+        let mut root = Default::default();
+        let mut trie = RLPSecTrieDBMut::new(&mut m, &mut root);
+
+        trie.insert("test-key1".as_bytes(), "test-vlue".as_bytes()).unwrap();
+        trie.insert("test-key2".as_bytes(), "test-value".as_bytes()).unwrap();
+        trie.insert("test-key11".as_bytes(), "test-value".as_bytes()).unwrap();
+        trie.insert("test-key12".as_bytes(), "test-value".as_bytes()).unwrap();
+        trie.insert("test-key13".as_bytes(), "test-value".as_bytes()).unwrap();
+
+        trie.root();
+    }
+
+    #[test]
+    fn test_remove_should_be_none() {
+        let mut m = MemoryDB::<Sha3Hasher>::default();
+        let mut root = Default::default();
+        let mut trie = RLPSecTrieDBMut::new(&mut m, &mut root);
+
+        trie.insert("test-key1".as_bytes(), "test-value".as_bytes()).unwrap();
+        let old_value = trie.remove("test-key1".as_bytes()).unwrap().unwrap();
+        assert_eq!(old_value, "test-value".as_bytes());
+        
+        let value = trie.get("test-key1".as_bytes()).unwrap().take();
+        assert_eq!(value, None)
+    }
+
+    #[test]
+    fn test_contains_should_be_false() {
+        let mut m = MemoryDB::<Sha3Hasher>::default();
+        let mut root = Default::default();
+        let trie = RLPSecTrieDBMut::new(&mut m, &mut root);
+
+        let contains = trie.contains("test-key1".as_bytes()).unwrap();
+        assert_eq!(contains, false)
+    }
+
+    #[test]
+    fn test_contains_should_be_true() {
+        let mut m = MemoryDB::<Sha3Hasher>::default();
+        let mut root = Default::default();
+        let mut trie = RLPSecTrieDBMut::new(&mut m, &mut root);
+
+        trie.insert("test-key1".as_bytes(), "test-value".as_bytes()).unwrap();
+        let contains = trie.contains("test-key1".as_bytes()).unwrap();
+        assert_eq!(contains, true)
+    }
+
+       #[test]
+    fn test_trie_from_existing() {
+        let mut m = MemoryDB::<Sha3Hasher>::default();
+        let mut new_root = {
+            let mut root = Default::default();
+            let mut trie = RLPSecTrieDBMut::new(&mut m, &mut root);
+            trie.insert("test-key1".as_bytes(), "test-value".as_bytes()).unwrap();
+            trie.insert("test-key2".as_bytes(), "test-value".as_bytes()).unwrap();
+            trie.insert("test-key11".as_bytes(), "test-value".as_bytes()).unwrap();
+            trie.insert("test-key11".as_bytes(), "test-value".as_bytes()).unwrap();
+            trie.get("test-key1".as_bytes()).unwrap().unwrap();
+            trie.root().clone()
+        };
+
+        let _ = RLPSecTrieDBMut::from_existing(&mut m, &mut new_root).unwrap();
+    }
+}


### PR DESCRIPTION
Dependent on [trie](https://github.com/paritytech/trie), a generic implementation of the Base-16 Modified Merkle Tree data structure.

To keep compatible with ETH and CITA-1.0, serialization still uses RLP.

cc @mohanson @u2 