### PR TITLE
Upgrade libsecp256k1 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ethereum-types = "0.4"
 hashbrown = { version = "0.3", features = ["rayon"] }
 hasher = { version="0.1" }
 hex = "0.3"
-libsecp256k1 = "0.2"
+libsecp256k1 = "0.3.1"
 log = "0.4"
 ripemd160 = "0.8"
 rlp = "0.3"


### PR DESCRIPTION
```sh
ID:	 RUSTSEC-2019-0027
Crate:	 libsecp256k1
Version: 0.2.2
Date:	 2019-10-14
Title:	 Flaw in Scalar::check_overflow allows side-channel timing attack
Solution: upgrade to: >= 0.3.1
```